### PR TITLE
Add cpp sample-program to use LOC-macros. Add Makefile rules to build cpp.

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -33,13 +33,13 @@ jobs:
       run: make clean
 
     - name: make-all-verbose
-      run: CC=gcc LD=gcc BUILD_VERBOSE=1 make
+      run: CC=gcc LD=g++ BUILD_VERBOSE=1 make
 
     #! Execute testing targets; Run py-test and LOC-enabled sample programs
     - name: make-tests
       run: |
         make clean
-        CC=gcc LD=gcc make run-tests
+        CC=gcc LD=g++ make run-tests
 
     #! - name: Run check
     #!   run: make check

--- a/test-code/single-file-cpp-program/single-file-main.cpp
+++ b/test-code/single-file-cpp-program/single-file-main.cpp
@@ -1,0 +1,47 @@
+/*
+ * This is a very simple demo program to show how the LOC macros can be used
+ * in couple of different ways, implemented in C++ code.
+ *
+ * 1. Explicitly generate the encoding using __LOC__
+ * 2. Hide the generation behind a caller-macro, FUNCTION2().
+ * 3. Caller's LOC is decoded inside the callee.
+ *
+ * This example program shows that LOC-macros are equally applicable
+ * in C++ code base.
+ */
+#include <iostream>
+#include "loc.h"
+
+using namespace std;
+
+// Caller-macro to invoke function and synthesize code-location
+#define FUNCTION2()     function2(__LOC__)
+
+static void
+function1(loc_t loc)
+{
+    cout << __FILE__ << ":" << __func__ << ":" <<  __LINE__
+         << ": Hello World! Called from "
+         << LOC_FILE(loc) << ":" << LOC_LINE(loc)
+         << endl;
+}
+
+static void
+function2(loc_t loc)
+{
+    cout << __FILE__ << ":" << __func__ << ":" <<  __LINE__
+         << ": Hello World! Called from "
+         << LOC_FILE(loc) << ":" << LOC_LINE(loc)
+         << ", __PRETTY_FUNCTION__=" << __PRETTY_FUNCTION__
+         << endl;
+}
+
+int
+main(int argc, const char *argv[])
+{
+    cout << __FILE__ << ":" << __func__ << ":" <<  __LINE__
+         << endl;
+    function1(__LOC__);
+
+    FUNCTION2();
+}

--- a/test-code/source-location-cpp-program/source-location-main-C++20.cpp
+++ b/test-code/source-location-cpp-program/source-location-main-C++20.cpp
@@ -1,0 +1,38 @@
+/*
+ * C++ 20 has intrinsic support for this file/line# combo through
+ * source_location object.
+ *
+ * This sample program is copied from:
+ * https://en.cppreference.com/w/cpp/utility/source_location
+ *
+ * NOTE: On the dev macOS machine, g++ is still at v13.xx
+ *       Leave this file named w/o "-main", so that it does not
+ *       get picked up by Makefile rules.
+ */
+#include <iostream>
+#include <source_location>
+#include <string_view>
+
+void log(const std::string_view message,
+         const std::source_location location =
+               std::source_location::current())
+{
+    std::clog << "file: "
+              << location.file_name() << '('
+              << location.line() << ':'
+              << location.column() << ") `"
+              << location.function_name() << "`: "
+              << message << '\n';
+}
+
+template<typename T>
+void fun(T x)
+{
+    log(x);
+}
+
+int main(int, char*[])
+{
+    log("Hello world!");
+    fun("Hello C++20!");
+}


### PR DESCRIPTION
This commit introduces a simple C++ example program using basic __LOC__ and LOC_*() decoding macros.    

- Fix Makefile to use g++ for cpp files.
- Simplify Makefile rules to use subst() [ rather than patsubst() ], to generate CFLAGS that will work for both
      .c and .cpp files.
- Use g++ as LD command.
- Cleanup Makefile to get builds working in all modes.