### PR TITLE
[LOC] L3-support: Add --loc-decoder-dir arg, and tests

### DIFF
--- a/loc/loc_xform.py
+++ b/loc/loc_xform.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+################################################################################
+# loc_xform.py
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+"""
+Helper module to encode (fileindex / line #) pair to LOC-ID and to decode LOC-ID
+# to constituent fileindex / line #.
+"""
+
+# LOC-encoding numbers. -HARD-Dependency on what's generated in loc.h
+LOC_NBITS_FILES = 15
+LOC_NBITS_LINES = 16
+LOC__MASK_LINES = 0xffff
+
+###############################################################################
+# Minimalist encode / decode routines live here
+#
+def loc_encode(file_index:int, line_num:int) -> int:
+    """
+    Encode a pair of (file-index, line#) and return a LOC-ID.
+    """
+    return (file_index << LOC_NBITS_LINES) | line_num
+#
+def loc_decode(loc_id:int) -> (int, int):
+    """
+    Crack open a LOC ID and return a pair (file-index, line#)
+    """
+    file_index = loc_id >> LOC_NBITS_LINES
+    line_num = loc_id & LOC__MASK_LINES
+    return (file_index, line_num)

--- a/tests/test_loc_xform.py
+++ b/tests/test_loc_xform.py
@@ -1,0 +1,39 @@
+# #############################################################################
+# test_loc_xform.py
+#
+"""
+Basic unit-test for LOC encode / decode Python methods.
+"""
+
+# #############################################################################
+import loc.loc_xform as xform
+
+# #############################################################################
+# Setup some variables pointing to diff dir/sub-dir full-paths.
+
+# #############################################################################
+# To see output from test-cases run:
+# $ pytest --capture=tee-sys tests/test_gen_loc_files_basic.py -k test_loc_main_scriptdir
+# #############################################################################
+def test_loc_encode():
+    """
+    Cross-check LOC-encoded value for few hard-coded inputs.
+    """
+    assert 65541 == xform.loc_encode(1, 5)
+    assert 131089 == xform.loc_encode(2, 17)
+
+# #############################################################################
+def test_loc_decode():
+    """
+    Cross-check LOC-decoded value for few hard-coded inputs.
+    """
+    assert (1, 5) == xform.loc_decode(65541)
+    assert (2, 17) == xform.loc_decode(131089)
+
+# #############################################################################
+def test_loc_encode_decode_roundtrip():
+    """
+    Cross-check LOC-encoding / decoding roundtrip.
+    """
+    (file_index, line_num) = xform.loc_decode(65541)
+    assert xform.loc_encode(file_index, line_num) == 65541


### PR DESCRIPTION
This commit enhances the LOC generator script to support the `--loc-decoder-dir` argument. This specifies the name of the output dir where the standalone `<program>_loc` binary will be generated. (Default remains Python's /tmp-dir.)

- Add loc/loc_xform.py module, with helper `loc_encode()` and  `loc_decode()` methods, to externalize the LOC interfaces for testing and use by other tools.

- Add tests for all changes, including new test_loc_xform.py

This set of changes are targetted to simplify the integration with the [L3 logging tool](https://github.com/undoio/l3).