### PR TITLE
[Test] Rename pytests to <something>_test.py; rename test-cases

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -62,6 +62,6 @@ From: Apache site
 
 A small collection of pytest tests exist to verify the LOC-generator
 
-- test_gen_loc_files_basic.py - Exercises basic generator functionality
-- test_gen_loc_files_oss_code_bases.py - Exercises the LOC generator script on
+- gen\_loc\_files\_basic\_test.py - Exercises basic generator functionality
+- gen\_loc\_files\_oss\_code\_bases\_test.py - Exercises the LOC generator script on
    above set of OSS source code bases. (This works offline on a private machine.)

--- a/tests/gen_loc_files_basic_test.py
+++ b/tests/gen_loc_files_basic_test.py
@@ -1,5 +1,5 @@
 # #############################################################################
-# test_gen_loc_files_basic.py
+# gen_loc_files_basic_test.py
 #
 """
 Collection of basic test cases to exercise the LOC generation machinery
@@ -29,7 +29,7 @@ LOC_ABBREV     = 'loc'
 
 # #############################################################################
 # To see output from test-cases run:
-# $ pytest --capture=tee-sys tests/test_gen_loc_files_basic.py -k test_loc_main_scriptdir
+# $ pytest --capture=tee-sys tests/gen_loc_files_basic_test.py -k test_loc_main_scriptdir
 # #############################################################################
 def test_loc_main_script_dir():
     """
@@ -69,7 +69,7 @@ def test_help():
     this raises() exception block to let the test case pass.
     If you want to see the --help output, do:
 
-      $ pytest --capture=tee-sys tests/test_gen_loc_files_basic.py -k test_help
+      $ pytest --capture=tee-sys tests/gen_loc_files_basic_test.py -k test_help
     """
     with pytest.raises(SystemExit):
         loc_main.loc_parse_args(['--help'])

--- a/tests/gen_loc_files_oss_code_bases_test.py
+++ b/tests/gen_loc_files_oss_code_bases_test.py
@@ -1,5 +1,5 @@
 # #############################################################################
-# test_gen_loc_files_oss_code_bases.py
+# gen_loc_files_oss_code_bases_test.py
 #
 """
 Exercise LOC py-generator on a collection of OSS code-bases that have
@@ -26,8 +26,6 @@ LocDirRoot    = os.path.realpath(LocTestsDir + '/..')
 LocDirsParent = os.path.realpath(LocDirRoot + '/..')
 
 # #############################################################################
-# To see output from test-cases run:
-# $ pytest --capture=tee-sys tests/test_gen_loc_files_basic.py -k test_loc_main_scriptdir
 # pylint: disable-msg=line-too-long
 # Ref: https://stackoverflow.com/questions/800197/how-to-get-all-of-the-immediate-subdirectories-in-python
 #      https://docs.python.org/3/tutorial/inputoutput.html

--- a/tests/loc_xform_test.py
+++ b/tests/loc_xform_test.py
@@ -1,5 +1,5 @@
 # #############################################################################
-# test_loc_xform.py
+# loc_xform_test.py
 #
 """
 Basic unit-test for LOC encode / decode Python methods.
@@ -11,9 +11,6 @@ import loc.loc_xform as xform
 # #############################################################################
 # Setup some variables pointing to diff dir/sub-dir full-paths.
 
-# #############################################################################
-# To see output from test-cases run:
-# $ pytest --capture=tee-sys tests/test_gen_loc_files_basic.py -k test_loc_main_scriptdir
 # #############################################################################
 def test_loc_encode():
     """


### PR DESCRIPTION
To be consistent with conventional test-code naming conventions, this commit renames existing pytest files to <something>_test.py E.g., test_gen_loc_files_basic.py -> gen_loc_files_basic_test.py

Individual test-cases are already named as test_<something>; E.g., in above test file, test method is named: test_loc_main_script_dir() and so on.