### PR TITLE
[Test] Verify & re-enable pytests to exercise unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,10 @@ GENERATED_OBJS := $(GENERATED_SRCS:%.c=$(OBJDIR)/%.o)
 # UNIT_TESTSRC := $(call rwildcard,$(UNIT_TESTSDIR),*.c)
 UNIT_TESTSRC := $(shell find $(TESTSDIR)/$(UNITDIR) -type f -name *.c -print)
 UNIT_TESTSRC += $(UNIT_GENSRC)
-UNIT_TESTSRC += $(SRCDIR)/$(LOCPACKAGE).c
+
+# One of the unit-test programs is written specifically to only use the
+# LOC_ELF encoding. So, we must always include the required source.
+UNIT_TESTSRC += $(LOC_ELF_SRC)
 
 # Objects from unit-test sources in tests/unit/ sub-dir, for unit-tests
 # Resolves to a list: obj/tests/unit/a.o obj/tests/unit/b.o obj/tests/unit/c.o
@@ -282,7 +285,7 @@ endif
 # Use this recursively defined variables to build the path to pick-up both
 # forms of #include .h files.
 # -----------------------------------------------------------------------------
-INCLUDE  = -I ./$(UNIT_INCDIR)
+INCLUDE := -I ./$(UNIT_INCDIR)
 INCLUDE += -I ./$(dir $<)
 INCLUDE += -I ./$(INCDIR)
 

--- a/tests/makefile_test.py
+++ b/tests/makefile_test.py
@@ -150,7 +150,6 @@ def test_make_run_unit_tests_loc_eq_0():
     verify_unit_test_gen_files()
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=1 build mode")
 def test_make_run_unit_tests_loc_eq_1():
     """Test `LOC_ENABLED=1 make run-unit-tests`"""
 
@@ -162,7 +161,6 @@ def test_make_run_unit_tests_loc_eq_1():
     verify_unit_test_gen_files()
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=2 build mode")
 def test_make_run_unit_tests_loc_elf():
     """Test `LOC_ENABLED=2 make run-unit-tests`"""
 

--- a/tests/unit/single_file_elf_src/single_file_prog_elf_test.c
+++ b/tests/unit/single_file_elf_src/single_file_prog_elf_test.c
@@ -4,6 +4,16 @@
  *
  * LOC test for a single file program, using LOC-variation based on ELF.
  * No Python generation is needed for this program. It relies only on loc.h
+ *
+ * The Makefile INCDIR rules for this file are written so that even if we
+ * run the builds with LOC_ENABLED=1 (i.e., LOC-files are generated), for this
+ * file, we #include the default include/loc.h . E.g., build output:
+ *
+ * ... gcc -DLOC_FILE_INDEX=LOC_single_file_prog_elf_test_c             \
+ *      -I ./tests/unit -I ./ -I ./include                              \
+ *      -c tests/unit/single_file_elf_src/single_file_prog_elf_test.c
+ *
+ * So, there is no dependency on the generation step.
  * -----------------------------------------------------------------------------
  */
 #include <string.h>


### PR DESCRIPTION
There is no real code change here; just a verification that existing pytests that exercise unit-tests still correctly build and execute unit-tests. Enable a few pytests that were skipped.