### PR TITLE
[Make] Conditionally use LOC_FUNC() in single_file_prog_test.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,16 @@ all: all-tests all-test-code
 #  - Replace "." with "_" (*.c -> *_c, *.cpp -> *_cpp, *.cc -> *_cc)
 # -----------------------------------------------------------------------------
 ifeq ($(LOC_GENERATE), $(LOC_DEFAULT))
+
     CFLAGS += -DLOC_FILE_INDEX=LOC_$(subst .,_,$(subst -,_,$(notdir $<)))
+
+else ifeq ($(LOC_ENABLED), $(LOC_ELF_ENCODING))
+    # NOTE: This is -NOT- needed normally in user's project sources.
+    #       We just add this to allow some conditionally defined code in one of
+    #       the unit-test sources to compile. (Being able to build that source
+    #       fragment confirms that we are correctly #include'ing include/loc.h
+    #       and not the generated loc.h file.)
+    CFLAGS += -DLOC_ELF_ENCODING
 endif
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/single_file_src/single_file_prog_test.c
+++ b/tests/unit/single_file_src/single_file_prog_test.c
@@ -10,6 +10,7 @@
 #include "loc.h"
 
 _Bool str_endswith(const char *str, const char *suffix);
+_Bool str_cmp_eq(const char *str1, const char *str2);
 
 /*
  * Global data declaration macro:
@@ -42,6 +43,16 @@ CTEST2(single_file_prog, test_basic_LOC)
     // Compare LOC-filename with actual file name.
     ASSERT_TRUE(str_endswith(__FILE__, file),
                 "Expected: '%s', Actual: '%s'\n", __FILE__, file);
+
+#if LOC_ELF_ENCODING
+    const char *func = LOC_FUNC(loc);
+
+    printf("__FUNC__='%s', LOC func='%s'\n", __FUNCTION__, func);
+
+    // Compare LOC-function name with actual function name.
+    ASSERT_TRUE(str_cmp_eq(__FUNCTION__, func),
+                "Expected: '%s', Actual: '%s'\n", __FUNCTION__, func);
+#endif  // LOC_ELF_ENCODING
 }
 
 /* Helper functions */


### PR DESCRIPTION
This commit verifies the use of macros that only exist in the LOC_ELF encoding scheme; i.e., `LOC_FUNC()`.

This macro is used in a file which normally is built using the generator. Makefile rules are added to `CFLAGS` to specify `-DLOC_ELF_ENCODING` when `make` is run with `LOC_ENABLED=2`.

These changes show that, depending on the setting of the `LOC_ENABLED` build-mode, we are correctly `#include`'ing the right generated `loc.h` or the `include/loc.h` file in the affected test-case file.