### PR TITLE
[Test] Support LOC_ENABLED=0, to run in LOC-ELF encoding mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ LOC_ELF_SRC         := $(SRCDIR)/loc.c
 # LOC-encoding comes in two flavours. Default technique is based on
 # Python-generator script. Enhanced technique is based on LOC-ELF
 # encoding.
+LOC_EXPLICITLY_UNSET := 0
 LOC_DEFAULT          := 1
 LOC_ELF_ENCODING     := 2
 
@@ -109,6 +110,8 @@ LOC_GENERATE := 0
 ifeq ($(LOC_ENABLED), $(LOC_DEFAULT))
     LOC_GENERATE := $(LOC_DEFAULT)
 else ifeq ($(LOC_ENABLED), $(LOC_ELF_ENCODING))
+    LOC_GENERATE := $(LOC_ELF_ENCODING)
+else ifeq ($(LOC_ENABLED), $(LOC_EXPLICITLY_UNSET))
     LOC_GENERATE := $(LOC_ELF_ENCODING)
 endif
 

--- a/tests/makefile_test.py
+++ b/tests/makefile_test.py
@@ -15,7 +15,6 @@ possible useful combinations that users could invoke.
 # #############################################################################
 import os
 import subprocess as sp
-import pytest
 
 # #############################################################################
 # Setup some variables pointing to diff dir/sub-dir full-paths.
@@ -51,7 +50,6 @@ def test_make_all():
     assert make_rv is True
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_all_loc_eq_0():
     """Test `LOC_ENABLED=0 make all`"""
 
@@ -71,7 +69,6 @@ def test_make_all_tests():
     assert make_rv is True
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_all_tests_loc_eq_0():
     """Test `LOC_ENABLED=0 make all-tests`"""
 
@@ -92,7 +89,6 @@ def test_make_all_run_tests():
     assert make_rv is True
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_all_run_tests_loc_eq_0():
     """Test `make all` followed by `LOC_ENABLED=0 make run-tests`"""
 
@@ -138,7 +134,6 @@ def test_make_run_unit_tests():
     verify_unit_test_gen_files()
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_run_unit_tests_loc_eq_0():
     """Test `LOC_ENABLED=1 make run-unit-tests`"""
 
@@ -147,7 +142,7 @@ def test_make_run_unit_tests_loc_eq_0():
                         { "BUILD_VERBOSE": "1", "CC": "gcc", "LD": "g++",
                           "LOC_ENABLED": LOC_EXPLICITLY_UNSET})
     assert make_rv is True
-    verify_unit_test_gen_files()
+    verify_unit_test_gen_files(loc_generate = False)
 
 # #############################################################################
 def test_make_run_unit_tests_loc_eq_1():
@@ -181,7 +176,6 @@ def test_make_all_test_code():
     assert make_rv is True
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_all_test_code_loc_eq_0():
     """Test `LOC_ENABLED=0 make all-test-code`"""
 
@@ -202,7 +196,6 @@ def test_make_run_test_code():
     verify_test_code_gen_files()
 
 # #############################################################################
-@pytest.mark.skip(reason="make fails with LOC_ENABLED=0 build mode")
 def test_make_run_test_code_loc_eq_0():
     """Test `LOC_ENABLED=1 make run-test-code`"""
 
@@ -211,7 +204,7 @@ def test_make_run_test_code_loc_eq_0():
                         { "BUILD_VERBOSE": "1", "CC": "gcc", "LD": "g++",
                           "LOC_ENABLED": LOC_EXPLICITLY_UNSET})
     assert make_rv is True
-    verify_test_code_gen_files()
+    verify_test_code_gen_files(loc_generate = False)
 
 # #############################################################################
 def test_make_run_test_code_loc_eq_1():


### PR DESCRIPTION
This commit enables the use of `LOC_ENABLED=0` to mean: "Run the LOC-ELF based encoding".

(We cannot -simply- turn OFF all LOC access, as tests are written to use those macros.)

- Makefile is changed to recognize this env-variable.
- Enabled previously-skipped pytests named '*loc_eq_0"