### PR TITLE
[CI] Extend CI jobs to run both on Linux & Mac/OSX.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,9 @@
+# ##############################################################################
+# This workflow will install required s/w components on Linux and Mac/OSX.
+# Run through different `make` targets to build-and-test test-code and
+# unit-tests, sample programs that invoke the LOC-encoding schemes.
+# ##############################################################################
+
 name: LineOfCode-Build and Test
 #! -----------------------------------------------------------------------------
 # Ref: For running jobs on Linux & Mac/OSX with one workflow.

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,9 +1,15 @@
+# ##############################################################################
 # This workflow will install Python dependencies, run tests and lint with a
 # single version of Python.
 # For more information see:
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# ##############################################################################
 
 name: Python pytests
+#! -----------------------------------------------------------------------------
+# Ref: For running jobs on Linux & Mac/OSX with one workflow.
+# https://stackoverflow.com/questions/57946173/github-actions-run-step-on-specific-os
+#! -----------------------------------------------------------------------------
 on:
   push:
     branches: [ "main" ]
@@ -16,7 +22,10 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Update build.yml to run on Mac/OSX (macos-latest)
- Update python-app.yml to run pytests on Mac/OSX